### PR TITLE
Import modules properly in plotting example

### DIFF
--- a/lessons/python/tutor_notes.md
+++ b/lessons/python/tutor_notes.md
@@ -1706,6 +1706,11 @@ Inflammation data files: ['data/inflammation-05.csv', 'data/inflammation-11.csv'
 ```bash
 $ nano analyse_files.py
 ```
+- **0 - import necessary modules**
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+```
 
 - **1 - show that we see each filename in turn**
 ```python


### PR DESCRIPTION
The variable name `plt` is never defined in the current version, but is used in a few places.  This addition ensures that `plt` and `np` make sense in the example.

Perhaps renumbering is also necessary, but I didn't want to make too many changes since perhaps this needs to be changed in a different repository.